### PR TITLE
fix: support additional Ring camera types

### DIFF
--- a/src/lib/ownRingDevice.ts
+++ b/src/lib/ownRingDevice.ts
@@ -1,4 +1,3 @@
-import util from "node:util";
 import { RingCamera, RingCameraKind, RingDeviceType, RingIntercom } from "ring-client-api";
 
 import { RingAdapter } from "../main";
@@ -64,6 +63,7 @@ export abstract class OwnRingDevice {
       case RingCameraKind.floodlight_pro:
       case RingCameraKind.spotlightw_v2:
       case RingCameraKind.jbox_v1:
+      case "doorbell_sunray":
       case "df_doorbell_clownfish":
       case "lpd_v3":
         return `doorbell`;
@@ -80,6 +80,7 @@ export abstract class OwnRingDevice {
       case RingCameraKind.stickup_cam_lunar:
       case RingCameraKind.stickup_cam_elite:
       case RingCameraKind.stickup_cam_longfin:
+      case "stickup_cam_mini_ptz_v1":
       case "stickup_cam_mini_v2":
       case "stickup_cam_medusa":
         return `stickup`;
@@ -89,7 +90,11 @@ export abstract class OwnRingDevice {
         adapter.log.error(
           `Device with Type ${deviceType} not yet supported, please inform dev Team via Github`
         );
-        adapter.log.info(`Unsupported Device Info: ${util.inspect(device, false, 1)}`);
+        adapter.log.info(
+          `Unsupported Device Info: id=${device?.id}, type=${deviceType}, ` +
+          `model=${device?.model ?? "unknown"}, ` +
+          `description=${device?.initialData?.description ?? "unknown"}`
+        );
     }
     return "unknown";
   }


### PR DESCRIPTION
## Summary

- classify Ring devices reporting `deviceType: "doorbell_sunray"` as regular doorbells
- classify Ring Pan-Tilt Indoor Cameras reporting `deviceType: "stickup_cam_mini_ptz_v1"` as stick-up cameras
- prevent unsupported-device diagnostics from logging the complete `RingCamera` object
- keep useful diagnostics limited to device ID, type, model and description

## Problem

Two current Ring devices report previously unknown device types:

- `doorbell_sunray`
- `stickup_cam_mini_ptz_v1`

The adapter therefore creates them below `unknown_<id>` instead of using its existing doorbell or stick-up camera implementations.

The unsupported-device log also serializes the complete device object. That object contains the Ring REST client and may expose authentication material such as refresh tokens in ioBroker logs.

## Expected behavior

- `doorbell_sunray` is created below `doorbell_<id>`
- `stickup_cam_mini_ptz_v1` is created below `stickup_<id>` and gains the existing camera functions such as motion events, snapshots, live video and siren support
- pan/tilt controls are not added by this change because the adapter currently has no PTZ state model
- future unknown-device diagnostics remain useful without printing authentication data

## Validation

- the branch is based directly on the current upstream `master`
- the final diff only touches `src/lib/ownRingDevice.ts`
- the mappings follow the existing doorbell and stick-up camera code paths
- the Ring product specification confirms that the Pan-Tilt Indoor Camera provides motion detection, live video and siren functionality compatible with the existing camera path
- the source change passed type checking, linting, package checks and unit tests in the fork
