### PR TITLE
fix: use public RingCamera API in unsupported-device log, add changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npx -p ring-client-api ring-auth-cli
 
 or
 
-```
+```bash
 # Unix 
 cd /opt/iobroker/node_modules/iobroker.ring/
 npm i ring-client-api
@@ -63,7 +63,7 @@ the fault of this adapter.
 
 1. Some datapoints got renamed to be more consistent (e.g. `livestream_request` got reduced to `request` as it already
    is in channel `livestream`).
-2. You can now configure wether you want to react on events (with recording, snapshot, ...) or not.
+2. You can now configure whether you want to react on events (with recording, snapshot, ...) or not.
 3. Binary states got removed.
 
 ### V3 Rewrite Breaking Changes
@@ -98,6 +98,10 @@ doorbell recorded video.
 	### **WORK IN PROGRESS**
 -->
 ### **WORK IN PROGRESS**
+- (Speedbreaker12) #993 Add doorbell_sunray (Battery Video Doorbell 2K) as doorbell
+- (Speedbreaker12) #993 #854 Add stickup_cam_mini_ptz_v1 (Pan-Tilt Indoor Cam) as stickup cam
+- (Speedbreaker12) #993 Unsupported device logging no longer dumps the whole device object (could expose the Ring refresh token in the log)
+- (GermanBluefox) Devices previously created below `unknown_<id>` are recreated below `doorbell_<id>` / `stickup_<id>`; the old objects stay behind and have to be deleted manually
 - (copilot) Adapter requires node.js >= 22 now
 - (copilot) Adapter requires admin >= 7.7.22 now
 - (copilot) Adapter requires js-controller >= 6.0.11 now

--- a/src/lib/ownRingDevice.ts
+++ b/src/lib/ownRingDevice.ts
@@ -91,9 +91,10 @@ export abstract class OwnRingDevice {
           `Device with Type ${deviceType} not yet supported, please inform dev Team via Github`
         );
         adapter.log.info(
-          `Unsupported Device Info: id=${device?.id}, type=${deviceType}, ` +
+          `Unsupported Device Info: id=${device?.id}, ` +
           `model=${device?.model ?? "unknown"}, ` +
-          `description=${device?.initialData?.description ?? "unknown"}`
+          `description=${device?.data?.description ?? "unknown"}, ` +
+          `hasSiren=${device?.hasSiren ?? "unknown"}, hasLight=${device?.hasLight ?? "unknown"}`
         );
     }
     return "unknown";


### PR DESCRIPTION
Follow-up to #993 (already merged).

## Changes

**`src/lib/ownRingDevice.ts`**

- `device?.initialData?.description` → `device?.data?.description`. `initialData` is declared `private` on both `RingCamera` and `RingIntercom`; reading it works today only because the `device` parameter is typed `any`, and it would silently degrade to `"unknown"` the moment ring-client-api switches to a `#private` field. `data` is the public getter that `OwnRingCamera` and `OwnRingIntercom` already use in their constructors.
- Dropped `type=${deviceType}` — it is already in the `log.error` line directly above.
- Added `hasSiren`/`hasLight`. For unsupported device types the Ring API returns `model: "Unknown Model"` (see #854), so `model` carries no diagnostic value, while the capability flags tell us what the device can actually do.

**`README.md`** — the changelog entries for #993 were missing. Added, including a note that affected devices move from `unknown_<id>` to `doorbell_<id>`/`stickup_<id>` and that the old objects are left behind (there is no cleanup logic in the adapter).

## Why the whitelist approach in #993 is right

Worth recording: dumping `device.data` instead would not be a safe alternative. `CameraData` contains `address`, `latitude` and `longitude`, so it would trade a leaked refresh token for a leaked home address in a log that users are explicitly asked to paste into public GitHub issues.

## Validation

`npm run check`, `npm run lint`, `npm test` (57 passing) and `npm run build` all pass.

Additionally smoke-tested against a real `RingCamera` instance constructed with a rest client carrying a token:

```
doorbell_sunray          -> doorbell
stickup_cam_mini_ptz_v1  -> stickup
brand_new_cam_v9         -> unknown
  [error] Device with Type brand_new_cam_v9 not yet supported, please inform dev Team via Github
  [info] Unsupported Device Info: id=700830455, model=Unknown Model, description=Kitchen Cam, hasSiren=true, hasLight=false

leaks refreshToken : false
leaks address/gps  : false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfS9mxwbW4f9NFuPm9HT6J
